### PR TITLE
I've implemented the `eventDrop` callback to persist event date changes.

### DIFF
--- a/Booking.html
+++ b/Booking.html
@@ -157,6 +157,18 @@
             allEvents = allEvents.filter(e => e.id !== info.event.id);
           }
         },
+        eventDrop: function(info) {
+          allEvents = allEvents.map(e => {
+            if (e.id === info.event.id) {
+              return {
+                ...e,
+                start: info.event.startStr,
+                end: info.event.end ? new Date(new Date(info.event.endStr).getTime() - 86400000).toISOString().split('T')[0] : info.event.startStr,
+              };
+            }
+            return e;
+          });
+        },
       });
       calendar.render();
     });


### PR DESCRIPTION
Previously, when you dragged and dropped events on the calendar, the changes were not saved to the underlying `allEvents` data array. This caused the event to revert to its original position when you filtered or re-rendered the calendar.

I've now added an `eventDrop` handler to the FullCalendar instance. This handler updates the corresponding event's start and end dates in the `allEvents` array, ensuring that the new position is persisted throughout your session. The logic correctly handles both single and multi-day events.